### PR TITLE
Use local reusable auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   auto-release-after-pr:
     if: github.event.pull_request.merged == true
-    uses: cyaris/svelte-lib/.github/workflows/auto-release.yml@2d425d791e578c14869c235774128b25748d15f0
+    uses: ./.github/workflows/shared-auto-release.yml
     with:
       pr-number: ${{ github.event.pull_request.number }}
       release-sha: ${{ github.event.pull_request.merge_commit_sha }}
@@ -41,7 +41,7 @@ jobs:
 
   auto-release-manual:
     if: github.event_name == 'workflow_dispatch'
-    uses: cyaris/svelte-lib/.github/workflows/auto-release.yml@2d425d791e578c14869c235774128b25748d15f0
+    uses: ./.github/workflows/shared-auto-release.yml
     with:
       pr-number: ${{ inputs.pr-number }}
       release-sha: ${{ inputs.release-sha || github.sha }}

--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -1,0 +1,326 @@
+name: Shared auto release
+
+on:
+  workflow_call:
+    inputs:
+      release-sha:
+        description: Commit SHA to evaluate and release.
+        required: false
+        type: string
+        default: ""
+      pr-number:
+        description: Pull request number associated with the merge.
+        required: false
+        type: string
+        default: ""
+      policy-path:
+        description: Local release policy path in the caller repository.
+        required: false
+        type: string
+        default: .github/release-policy.yml
+      openai-model:
+        description: OpenAI model used to decide release milestones and write release notes.
+        required: false
+        type: string
+        default: gpt-5-mini
+      default-branch:
+        description: Default branch name. Leave blank to use the repository default branch.
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: Decide and report the release without publishing it.
+        required: false
+        type: boolean
+        default: false
+      svelte-lib-repository:
+        description: Repository containing the shared release policy.
+        required: false
+        type: string
+        default: cyaris/svelte-lib
+      svelte-lib-ref:
+        description: Ref used to read the shared release policy.
+        required: false
+        type: string
+        default: cy_dev3
+    secrets:
+      OPENAI_API_KEY:
+        description: OpenAI API key used for automated release decisions.
+        required: true
+      RELEASE_TOKEN:
+        description: Optional token with permission to create releases and tags.
+        required: false
+      CHECKOUT_TOKEN:
+        description: Optional token with read access to the shared svelte-lib repository.
+        required: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: auto-release-${{ github.repository }}-${{ inputs.release-sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: caller
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Gather release context
+        id: context
+        working-directory: caller
+        env:
+          DEFAULT_BRANCH_INPUT: ${{ inputs.default-branch }}
+          EVENT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          POLICY_PATH: ${{ inputs.policy-path }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          RELEASE_SHA_INPUT: ${{ inputs.release-sha }}
+        run: |
+          set -euo pipefail
+
+          default_branch="${DEFAULT_BRANCH_INPUT:-$EVENT_DEFAULT_BRANCH}"
+          release_sha="${RELEASE_SHA_INPUT:-$(git rev-parse HEAD)}"
+
+          git fetch --force --tags origin
+          if [[ -n "$default_branch" ]]; then
+            git fetch --force origin "$default_branch:refs/remotes/origin/$default_branch"
+          fi
+
+          if ! git cat-file -e "${release_sha}^{commit}" 2>/dev/null; then
+            git fetch --force origin "$release_sha"
+          fi
+
+          latest_release_json="$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName,name,publishedAt --jq '.[0] // {}' 2>/dev/null || printf '{}')"
+          latest_tag="$(node -e 'const data = JSON.parse(process.argv[1]); process.stdout.write(data.tagName || "")' "$latest_release_json")"
+
+          range="$release_sha"
+          if [[ -n "$latest_tag" ]] && git rev-parse -q --verify "refs/tags/$latest_tag^{commit}" >/dev/null; then
+            range="$latest_tag..$release_sha"
+          fi
+
+          git log --reverse --date=short --format="- %h %ad %s" "$range" -- > ../commits.all.txt
+          sed -n '1,120p' ../commits.all.txt > ../commits.txt
+
+          if [[ "$range" == *".."* ]]; then
+            git diff --name-only "$range" -- > ../files.all.txt
+          else
+            git ls-tree -r --name-only "$release_sha" > ../files.all.txt
+          fi
+          sed -n '1,200p' ../files.all.txt > ../files.txt
+
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr view "$PR_NUMBER" --json number,title,body,labels,baseRefName,headRefName,url,mergedAt,mergeCommit,files > ../pr.json
+          else
+            printf "{}" > ../pr.json
+          fi
+
+          export DEFAULT_BRANCH="$default_branch"
+          export LATEST_RELEASE_JSON="$latest_release_json"
+          export RELEASE_SHA="$release_sha"
+
+          node <<'NODE'
+          const fs = require("fs")
+
+          const read = (path, max = 20000) => {
+            try {
+              return fs.readFileSync(path, "utf8").slice(0, max)
+            } catch {
+              return ""
+            }
+          }
+
+          const context = {
+            repository: process.env.GITHUB_REPOSITORY,
+            defaultBranch: process.env.DEFAULT_BRANCH || "",
+            releaseSha: process.env.RELEASE_SHA || "",
+            policyPath: process.env.POLICY_PATH,
+            basePolicy: read("../svelte-lib/.github/release-policy.yml"),
+            localPolicy: read(process.env.POLICY_PATH),
+            agentsGuidance: read("AGENTS.md", 24000),
+            latestRelease: JSON.parse(process.env.LATEST_RELEASE_JSON || "{}"),
+            pullRequest: JSON.parse(read("../pr.json") || "{}"),
+            commits: read("../commits.txt"),
+            changedFiles: read("../files.txt")
+          }
+
+          fs.writeFileSync("../release-context.json", JSON.stringify(context, null, 2))
+          NODE
+
+      - name: Decide release
+        id: decide
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ inputs.openai-model }}
+        run: |
+          set -euo pipefail
+
+          node <<'NODE'
+          const fs = require("fs")
+
+          const context = JSON.parse(fs.readFileSync("release-context.json", "utf8"))
+          const schema = {
+            type: "object",
+            additionalProperties: false,
+            required: ["create_release", "tag", "title", "notes", "reason"],
+            properties: {
+              create_release: { type: "boolean" },
+              tag: { type: "string" },
+              title: { type: "string" },
+              notes: { type: "string" },
+              reason: { type: "string" }
+            }
+          }
+
+          const system = [
+            "You decide whether a merged pull request marks a release milestone.",
+            "Use the base release policy, then apply any local policy overrides.",
+            "Create releases only for meaningful milestones, not routine maintenance.",
+            "Pick the next tag using the repository's existing release history and policy.",
+            "The tag must be a new tag, must not contain spaces or slashes, and should normally start with v.",
+            "Write concise GitHub release notes for users and future maintainers.",
+            "Return only JSON that matches the provided schema."
+          ].join(" ")
+
+          const body = {
+            model: process.env.OPENAI_MODEL,
+            input: [
+              { role: "system", content: system },
+              { role: "user", content: JSON.stringify(context, null, 2) }
+            ],
+            text: {
+              format: {
+                type: "json_schema",
+                name: "release_decision",
+                strict: true,
+                schema
+              }
+            }
+          }
+
+          const response = await fetch("https://api.openai.com/v1/responses", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify(body)
+          })
+
+          const data = await response.json()
+          if (!response.ok) {
+            throw new Error(`OpenAI API request failed: ${response.status} ${JSON.stringify(data)}`)
+          }
+
+          const outputText = data.output_text || (data.output || [])
+            .flatMap((item) => item.content || [])
+            .find((content) => content.type === "output_text")?.text
+
+          if (!outputText) {
+            throw new Error(`OpenAI response did not include output text: ${JSON.stringify(data)}`)
+          }
+
+          const decision = JSON.parse(outputText)
+          decision.create_release = Boolean(decision.create_release)
+          decision.tag = String(decision.tag || "").trim()
+          decision.title = String(decision.title || "").replace(/\s+/g, " ").trim()
+          decision.notes = String(decision.notes || "").trim()
+          decision.reason = String(decision.reason || "").trim()
+
+          fs.writeFileSync("release-decision.json", JSON.stringify(decision, null, 2))
+          fs.writeFileSync("release-notes.md", decision.notes + "\n")
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `create_release=${decision.create_release}\n`)
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${decision.tag}\n`)
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `title=${decision.title}\n`)
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `reason<<REASON\n${decision.reason}\nREASON\n`)
+          NODE
+
+      - name: Publish release
+        if: steps.decide.outputs.create_release == 'true' && inputs.dry-run == false
+        working-directory: caller
+        env:
+          DEFAULT_BRANCH_INPUT: ${{ inputs.default-branch }}
+          EVENT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          RELEASE_SHA_INPUT: ${{ inputs.release-sha }}
+          TAG: ${{ steps.decide.outputs.tag }}
+          TITLE: ${{ steps.decide.outputs.title }}
+        run: |
+          set -euo pipefail
+
+          default_branch="${DEFAULT_BRANCH_INPUT:-$EVENT_DEFAULT_BRANCH}"
+          release_sha="${RELEASE_SHA_INPUT:-$(git rev-parse HEAD)}"
+
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){0,2}([._-][A-Za-z0-9]+)?$ ]] || [[ "$TAG" == *..* ]]; then
+            printf "Invalid release tag: %s\n" "$TAG" >&2
+            exit 1
+          fi
+
+          if [[ -z "$TITLE" ]]; then
+            printf "Release title cannot be empty.\n" >&2
+            exit 1
+          fi
+
+          git fetch --force --tags origin
+
+          if git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
+            printf "Release tag already exists locally: %s\n" "$TAG" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            printf "Release tag already exists on origin: %s\n" "$TAG" >&2
+            exit 1
+          fi
+
+          if [[ -n "$default_branch" ]]; then
+            git fetch --force origin "$default_branch:refs/remotes/origin/$default_branch"
+            git merge-base --is-ancestor "$release_sha" "origin/$default_branch"
+          fi
+
+          gh release create "$TAG" --target "$release_sha" --title "$TITLE" --notes-file ../release-notes.md --latest
+
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr comment "$PR_NUMBER" --body "Auto release published ${TAG}: ${TITLE}" || true
+          fi
+
+      - name: Report no release
+        if: steps.decide.outputs.create_release != 'true'
+        working-directory: caller
+        env:
+          PR_NUMBER: ${{ inputs.pr-number }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          set -euo pipefail
+
+          printf "No release published: %s\n" "$REASON"
+
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr comment "$PR_NUMBER" --body "Auto release checked this merge and did not publish a release: ${REASON}" || true
+          fi
+
+      - name: Report dry run
+        if: steps.decide.outputs.create_release == 'true' && inputs.dry-run == true
+        env:
+          TAG: ${{ steps.decide.outputs.tag }}
+          TITLE: ${{ steps.decide.outputs.title }}
+        run: |
+          set -euo pipefail
+          printf "Dry run selected release %s: %s\n" "$TAG" "$TITLE"


### PR DESCRIPTION
## Summary\n- add a local reusable auto-release workflow\n- update the Auto release wrapper to call the local workflow instead of the private svelte-lib reusable workflow\n- remove the startup failure caused by GitHub being unable to resolve the private cross-repo workflow\n\n## Validation\n- parsed auto-release workflow YAML files locally