### PR TITLE
Clip Profile Photo animation overflow at the html element

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,17 +2,17 @@
 layout: null
 ---
 
-/* --- Body --- */
+/* --- Root And Body --- */
+
+html:has(.profile-photo) {
+  overflow-x: clip;
+}
 
 body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 1rem;
   overscroll-behavior-x: none;
   touch-action: manipulation;
-}
-
-body:has(.profile-photo) {
-  overflow-x: clip;
 }
 
 /* --- Sticky Footer Content --- */


### PR DESCRIPTION
Clips the profile photo animation's intentional canvas overflow at the root element instead of `body`, since Chrome does not propagate `overflow-x: clip` from `body` to the viewport. The laser-eye canvas extends 75% of the portrait width past each edge, and absolutely positioned boxes still extend the scrollable overflow region even when clipped visually, so the page was scrolling roughly 252px to the right of the portrait on any viewport under ~1120px wide. This was masked on mobile until the viewport zoom lock was removed in a prior release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal overflow handling on pages containing profile photos.
  * Updated page-level styling to ensure overflow behavior is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
